### PR TITLE
Revert failed ephox to hugemce replacement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,0 @@
-* @tinymce/tinymce-reviewers
-
-# Oxide changes should include the design team as well
-/modules/oxide/ @tinymce/tinymce-reviewers @noxuhax
-/modules/oxide-icons-default/ @tinymce/tinymce-reviewers @noxuhax
-
-# Katamari changes should include the integrations team as well
-/modules/katamari/ @tinymce/tinymce-reviewers @tinymce/integrations-team

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F41B Bug report"
 about: Create a bug report to help us improve
-labels: type:bug
+labels: bug
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: "⭐ Feature request"
 about: Propose an improvement or something new.
-labels: feature
+labels: enhancement
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: "⭐ Feature request"
 about: Propose an improvement or something new.
-labels: type:feature
+labels: feature
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -87,5 +87,6 @@
     "webpack": "^5.74.0",
     "webpack-cli": "^5.1.1",
     "webpack-dev-server": "^4.11.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Related Ticket: #8
I have done a rebase in the revert-failed-ephox-hugemce-replacement branch and dropped all the past commits after d6e5bb02b2 (including those from @mikkorantalainen – many thanks for them, but I don't want to have them as long as they aren't necessary) except for some which can be seen in this PR. As they have been rebased and the other commits just dropped, it looks like they have been added although in reality, this PR just reverts all the other commits since d6e5bb02b2 that do NOT exist in this PR. It's a bit dirty, yes...I could just have reverted the commits, but then there's a little conflict...it was easy to solve, but then I would have to manually commit instead of Git doing it...maybe it would have been worked when using the command line instead of GitHub desktop...but anyway, I now decided to do it this way. (I didn't want to force-push to main.)