### PR TITLE
#131 Avoid HTML entities being evaluated in pasted URLs

### DIFF
--- a/modules/hugerte/src/core/main/ts/api/commands/LinkCommands.ts
+++ b/modules/hugerte/src/core/main/ts/api/commands/LinkCommands.ts
@@ -9,7 +9,7 @@ export const registerCommands = (editor: Editor): void => {
 
     if (Type.isObject(linkDetails) && Type.isString(linkDetails.href)) {
       // Spaces are never valid in URLs and it's a very common mistake for people to make so we fix it here.
-      linkDetails.href = linkDetails.href.replace(/ /g, '%20');
+      linkDetails.href = linkDetails.href.replace(/&amp;/g, '&').replace(/ /g, '%20');
 
       // Remove existing links if there could be child links or that the href isn't specified
       if (!anchor || !linkDetails.href) {

--- a/modules/hugerte/src/core/main/ts/paste/Clipboard.ts
+++ b/modules/hugerte/src/core/main/ts/paste/Clipboard.ts
@@ -6,6 +6,7 @@ import Env from '../api/Env';
 import { BlobCache, BlobInfo } from '../api/file/BlobCache';
 import { ParserArgs } from '../api/html/DomParser';
 import * as Options from '../api/Options';
+import Entities from '../api/html/Entities';
 import Delay from '../api/util/Delay';
 import { EditorEvent } from '../api/util/EventDispatcher';
 import VK from '../api/util/VK';
@@ -215,6 +216,12 @@ const insertClipboardContent = (editor: Editor, clipboardContent: ClipboardConte
       content = clipboardContent['text/plain'];
     } else {
       content = PasteUtils.innerText(content);
+    }
+    // If we are extracting raw text but pasting it as HTML, we MUST encode it
+    // so the browser doesn't interpret characters like '&' as HTML entities.
+    // Note that the plain text mode should not be forced, otherwise SmartPaste does not work
+    if (!plainTextMode) {
+      content = Entities.encodeRaw(content);
     }
   }
 

--- a/modules/hugerte/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/hugerte/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -330,6 +330,15 @@ describe('browser.hugerte.core.FormattingCommandsTest', () => {
     TinyAssertions.assertContent(editor, '<p><a href="foo%20bar">test 123</a></p>');
   });
 
+  it('mceInsertLink (link with parameters)', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>test 123</p>');
+    editor.execCommand('SelectAll');
+    editor.execCommand('mceInsertLink', false, { href: 'http://example.com?foo=bar&amp;notes' });
+    // Note that &amp; should not be double encoded
+    TinyAssertions.assertContent(editor, '<p><a href="http://example.com?foo=bar&amp;notes">test 123</a></p>');
+  });
+
   it('mceInsertLink (link floated img)', () => {
     const editor = hook.editor();
     editor.setContent('<p><img style="float: right;" src="about:blank" /></p>');

--- a/modules/hugerte/src/core/test/ts/browser/paste/PasteTest.ts
+++ b/modules/hugerte/src/core/test/ts/browser/paste/PasteTest.ts
@@ -1,7 +1,8 @@
 import { afterEach, before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Singleton } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { Clipboard as AgarClipboard, Waiter } from '@ephox/agar';
 import { assert } from 'chai';
 
 import Editor from 'hugerte/core/api/Editor';
@@ -348,6 +349,24 @@ describe('browser.hugerte.core.paste.PasteTest', () => {
     assert.equal(PasteUtils.trimHtml('<span class="Apple-converted-space">\u00a0<\/span>b'), ' b');
     assert.equal(PasteUtils.trimHtml('a<span class="Apple-converted-space">\u00a0<\/span>'), 'a ');
     assert.equal(PasteUtils.trimHtml('<span class="Apple-converted-space">\u00a0<\/span>'), ' ');
+  });
+
+  context('html paste', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/hugerte/js/hugerte',
+      paste_as_text: false
+    });
+    it('#131 Pasting URL with parameters is encoded correctly', async () => {
+      const editor = hook.editor();
+      AgarClipboard.pasteDataTransfer(TinyDom.body(editor), (dataTransfer) => {
+        dataTransfer.setData('text/html', 'http://example.com?foo=bar&amp;notes');
+        dataTransfer.setData('text/plain', 'http://example.com?foo=bar&notes');
+      });
+
+      await Waiter.pTryUntilPredicate(`Wait for content to be pasted`, () => editor.getContent().includes("example.com"));
+
+      TinyAssertions.assertContent(editor, '<p>http://example.com?foo=bar&amp;notes</p>');
+    });
   });
 
   context('paste_webkit_styles', () => {

--- a/modules/hugerte/src/core/test/ts/browser/paste/SmartPasteTest.ts
+++ b/modules/hugerte/src/core/test/ts/browser/paste/SmartPasteTest.ts
@@ -142,6 +142,17 @@ describe('browser.hugerte.core.paste.SmartPasteTest', () => {
       assert.lengthOf(editor.undoManager.data, 3);
     });
 
+    it('paste as content, paste url with parameters as html', () => {
+      const editor = hook.editor();
+      editor.resetContent('<p>abc</p>');
+      LegacyUnit.setSelection(editor, 'p', 0, 'p', 3);
+      editor.undoManager.add();
+
+      editor.execCommand('mceInsertClipboardContent', false, { html: '<span>http://example.com?foo=bar&amp;baz</span>' });
+      TinyAssertions.assertContent(editor, '<p><a href="http://example.com?foo=bar&amp;baz">abc</a></p>');
+      assert.lengthOf(editor.undoManager.data, 3);
+    });
+
     it('TBA: paste as content, paste image url', () => {
       const editor = hook.editor();
       editor.resetContent('<p>abc</p>');


### PR DESCRIPTION
Issue fixed #131 
When pasting URL copied in Firefox, like `http://example.com?asdf&notes`, the `&not` is evaluated as html entity so it pastes `http://example.com?asdf¬es`

The fix consist of two steps:
- Escape HTML characters when pasting URLs (as previously the plain variant of them was inserted as HTML)
- When inserting a link, unescape & characters. Note that this was anyway a bug which was already fixed in TinyMCE, not just because of the change above.