### PR TITLE
Fix toggling lists

### DIFF
--- a/modules/hugerte/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/hugerte/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -193,10 +193,7 @@ const getSelectedTextBlocks = (editor: Editor, rng: Range, root: Node): HTMLElem
 
 const hasCompatibleStyle = (dom: DOMUtils, sib: Element, detail: ListDetail): boolean => {
   const sibStyle = dom.getStyle(sib, 'list-style-type');
-  let detailStyle = detail ? detail['list-style-type'] : '';
-
-  detailStyle = detailStyle === null ? '' : detailStyle;
-
+  const detailStyle = detail['list-style-type'] ?? '';
   return sibStyle === detailStyle;
 };
 
@@ -345,7 +342,7 @@ const updateCustomList = (editor: Editor, list: Element, listName: 'UL' | 'OL' |
 
 const toggleMultipleLists = (editor: Editor, parentList: HTMLElement | null, lists: HTMLElement[], listName: 'UL' | 'OL' | 'DL', detail: ListDetail): void => {
   const parentIsList = NodeType.isListNode(parentList);
-  if (parentIsList && parentList.nodeName === listName && !hasListStyleDetail(detail) && !isCustomList(parentList)) {
+  if (parentIsList && parentList.nodeName === listName && hasCompatibleStyle(editor.dom, parentList, detail) && !isCustomList(parentList)) {
     flattenListSelection(editor);
   } else {
     applyList(editor, listName, detail);
@@ -362,17 +359,13 @@ const toggleMultipleLists = (editor: Editor, parentList: HTMLElement | null, lis
   }
 };
 
-const hasListStyleDetail = (detail: ListDetail): boolean => {
-  return 'list-style-type' in detail;
-};
-
 const toggleSingleList = (editor: Editor, parentList: HTMLElement | null, listName: 'UL' | 'OL' | 'DL', detail: ListDetail): void => {
   if (parentList === editor.getBody()) {
     return;
   }
 
   if (parentList) {
-    if (parentList.nodeName === listName && !hasListStyleDetail(detail) && !isCustomList(parentList)) {
+    if (parentList.nodeName === listName && hasCompatibleStyle(editor.dom, parentList, detail) && !isCustomList(parentList)) {
       flattenListSelection(editor);
     } else {
       const bookmark = Bookmark.createBookmark(editor.selection.getRng());

--- a/modules/hugerte/src/plugins/lists/test/ts/browser/RemoveTest.ts
+++ b/modules/hugerte/src/plugins/lists/test/ts/browser/RemoveTest.ts
@@ -61,6 +61,25 @@ describe('browser.hugerte.plugins.lists.RemoveTest', () => {
     assert.equal(editor.selection.getStart().nodeName, 'P');
   });
 
+  it('TBA: Remove UL with specific list style', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<ul style="list-style-type: circle">' +
+      '<li>test</li>' +
+      '</ul>'
+    );
+
+    LegacyUnit.setSelection(editor, 'li', 0);
+    editor.execCommand('InsertUnorderedList', false, {
+      'list-style-type': 'circle'
+    });
+
+    TinyAssertions.assertContent(editor,
+      '<p>test</p>'
+    );
+    assert.equal(editor.selection.getNode().nodeName, 'P');
+  });
+
   it('TBA: Remove UL at start empty LI', () => {
     const editor = hook.editor();
     editor.setContent(


### PR DESCRIPTION
This PR aims to address #81 and should not contain breaking changes.

The Issue was in the logic that determined if the result state is already present in which case the _toggle_ should remove the list:

Previously it only checked if the passed style wants a specific `list-style-type`, but it needs to check whether the requested style is present or not.
