### PR TITLE
fix: undo after backspace reverts entire typing session

### DIFF
--- a/modules/hugerte/src/core/main/ts/undo/Setup.ts
+++ b/modules/hugerte/src/core/main/ts/undo/Setup.ts
@@ -1,4 +1,4 @@
-import { Cell } from '@ephox/katamari';
+import { Cell, Optional } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
 import Env from '../api/Env';
@@ -22,10 +22,20 @@ const shouldIgnoreCommand = (cmd: string): boolean => {
 
 export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: Locks): void => {
   const isFirstTypedCharacter = Cell(false);
+  const typingDirection = Cell<Optional<'forward' | 'backward'>>(Optional.none());
 
   const addNonTypingUndoLevel = (e?: EditorEvent<any>) => {
+    typingDirection.set(Optional.none());
     setTyping(undoManager, false, locks);
     undoManager.add({}, e);
+  };
+
+  const startTypingSession = (direction: 'forward' | 'backward', e: EditorEvent<KeyboardEvent>) => {
+    undoManager.beforeChange();
+    setTyping(undoManager, true, locks);
+    undoManager.add({} as UndoLevel, e);
+    typingDirection.set(Optional.some(direction));
+    isFirstTypedCharacter.set(true);
   };
 
   // Add initial undo level when the editor is initialized
@@ -105,18 +115,56 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
       if (undoManager.typing) {
         addNonTypingUndoLevel(e);
       }
+      typingDirection.set(Optional.none());
 
       return;
     }
 
+    const isDelete = keyCode === 8 || keyCode === 46;
+
     // If key isn't Ctrl+Alt/AltGr
     const modKey = (e.ctrlKey && !e.altKey) || e.metaKey;
-    if ((keyCode < 16 || keyCode > 20) && keyCode !== 224 && keyCode !== 91 && !undoManager.typing && !modKey) {
-      undoManager.beforeChange();
-      setTyping(undoManager, true, locks);
-      undoManager.add({} as UndoLevel, e);
-      isFirstTypedCharacter.set(true);
+
+    // Direction-aware typing: backspace/delete during forward typing ends the
+    // forward session and starts a backward one, and vice versa. This ensures
+    // undo after backspace reverts only the deletions, not the entire typing session.
+    if (isDelete) {
+      if (undoManager.typing) {
+        typingDirection.get().fold(
+          // No direction set yet (shouldn't happen), treat as backward start
+          () => {
+            addNonTypingUndoLevel(e);
+            startTypingSession('backward', e);
+          },
+          (dir) => {
+            if (dir !== 'backward') {
+              // Switching from forward typing to backward deletion
+              addNonTypingUndoLevel(e);
+              startTypingSession('backward', e);
+            }
+            // If already in backward mode, just continue coalescing
+          }
+        );
+      } else if (!modKey) {
+        // Not currently typing, start a backward session
+        startTypingSession('backward', e);
+      }
       return;
+    }
+
+    if ((keyCode < 16 || keyCode > 20) && keyCode !== 224 && keyCode !== 91 && !undoManager.typing && !modKey) {
+      startTypingSession('forward', e);
+      return;
+    }
+
+    // Switching from backward deletion to forward typing
+    if (undoManager.typing && !isDelete) {
+      typingDirection.get().each((dir) => {
+        if (dir === 'backward') {
+          addNonTypingUndoLevel(e);
+        }
+      });
+      typingDirection.set(Optional.some('forward'));
     }
 
     const hasOnlyMetaOrCtrlModifier = Env.os.isMacOS() ? e.metaKey : e.ctrlKey && !e.altKey;
@@ -129,6 +177,7 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
     if (undoManager.typing) {
       addNonTypingUndoLevel(e);
     }
+    typingDirection.set(Optional.none());
   });
 
   // Special inputType, currently only Chrome implements this: https://www.w3.org/TR/input-events-2/#x5.1.2-attributes

--- a/modules/hugerte/src/core/main/ts/undo/Setup.ts
+++ b/modules/hugerte/src/core/main/ts/undo/Setup.ts
@@ -125,10 +125,11 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
     // If key isn't Ctrl+Alt/AltGr
     const modKey = (e.ctrlKey && !e.altKey) || e.metaKey;
 
-    // Direction-aware typing: backspace/delete during forward typing ends the
+    // Direction-aware typing: plain backspace/delete during forward typing ends the
     // forward session and starts a backward one, and vice versa. This ensures
     // undo after backspace reverts only the deletions, not the entire typing session.
-    if (isDelete) {
+    // Ctrl/Meta+delete (e.g., word deletion) is handled by hasOnlyMetaOrCtrlModifier below.
+    if (isDelete && !modKey) {
       if (undoManager.typing) {
         typingDirection.get().fold(
           // No direction set yet (shouldn't happen), treat as backward start
@@ -145,7 +146,7 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
             // If already in backward mode, just continue coalescing
           }
         );
-      } else if (!modKey) {
+      } else {
         // Not currently typing, start a backward session
         startTypingSession('backward', e);
       }

--- a/modules/hugerte/src/core/main/ts/undo/Setup.ts
+++ b/modules/hugerte/src/core/main/ts/undo/Setup.ts
@@ -163,9 +163,12 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
       typingDirection.get().each((dir) => {
         if (dir === 'backward') {
           addNonTypingUndoLevel(e);
+          startTypingSession('forward', e);
         }
       });
-      typingDirection.set(Optional.some('forward'));
+      if (typingDirection.get().isNone()) {
+        typingDirection.set(Optional.some('forward'));
+      }
     }
 
     const hasOnlyMetaOrCtrlModifier = Env.os.isMacOS() ? e.metaKey : e.ctrlKey && !e.altKey;


### PR DESCRIPTION
## Description

Makes undo after backspace/delete only revert the deletions, not the entire typing session, by introducing direction-aware typing sessions.

## Changes

1. **Direction-aware typing sessions** — tracks whether the current typing burst is forward (inserting) or backward (deleting). Switching direction ends the current session and starts a new one, so they occupy separate undo levels.

2. **Respect Ctrl+Backspace** — modifier+delete keys (word deletion) fall through to the existing hasOnlyMetaOrCtrlModifier handler rather than being consumed by the new logic.

3. **Fix orphaned first character** — when switching from backward to forward, immediately starts a forward session so the first typed character is captured in the undo level, not orphaned outside any session.