### PR TITLE
fix: guard against undefined value in Preview.getCssText color checks

### DIFF
--- a/modules/hugerte/src/core/main/ts/fmt/Preview.ts
+++ b/modules/hugerte/src/core/main/ts/fmt/Preview.ts
@@ -287,7 +287,8 @@ const getCssText = (editor: Editor, format: string | ApplyFormat): string => {
 
       // Ignore white since it's the default color, not the nicest fix
       // TODO: Fix this by detecting runtime style
-      if (Transformations.rgbaToHexString(value).toLowerCase() === '#ffffff') {
+      const hex = Transformations.rgbaToHexString(value);
+      if (hex && hex.toLowerCase() === '#ffffff') {
         return;
       }
     }
@@ -295,7 +296,8 @@ const getCssText = (editor: Editor, format: string | ApplyFormat): string => {
     if (name === 'color') {
       // Ignore black since it's the default color, not the nicest fix
       // TODO: Fix this by detecting runtime style
-      if (Transformations.rgbaToHexString(value).toLowerCase() === '#000000') {
+      const hex = Transformations.rgbaToHexString(value);
+      if (hex && hex.toLowerCase() === '#000000') {
         return;
       }
     }


### PR DESCRIPTION
## Description

Fixes #171.

When a format involves a custom element tag (e.g. from Stripe Elements), `dom.getStyle` can return `undefined` because `isHTMLElement` fails for cross-document custom elements. The code then calls `rgbaToHexString(undefined).toLowerCase()`, which throws:

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
```

## Root cause

`Preview.getCssText` creates preview elements using the global `DOMUtils.DOM` singleton (operating on the main document), then appends them to the editor's iframe body. For custom elements, `SandHTMLElement.isPrototypeOf` fails because:

1. `iframe.HTMLElement.prototype.isPrototypeOf(x)` returns `false` when `x` was constructed in the main window's realm
2. The regex fallback `/^HTML\w*Element$/` does not match custom element constructor names like `StripeElement`

Standard elements are unaffected because the regex matches names like `HTMLDivElement`.

## Fix

Add a null/undefined guard before the `.toLowerCase()` calls for the `background-color` and `color` preview filters in `Preview.ts`.

Reproductions are available in `/srv/hugerte/hugerte-bug-repro/`.