### PR TITLE
test: fix AnnotationStylingTest for Chrome 147+ outline-width change

### DIFF
--- a/modules/hugerte/src/core/test/ts/browser/annotate/AnnotationStylingTest.ts
+++ b/modules/hugerte/src/core/test/ts/browser/annotate/AnnotationStylingTest.ts
@@ -74,8 +74,8 @@ describe('browser.hugerte.core.annotate.AnnotationStylingTest', () => {
 
   const getOutline = (elm: SugarElement<Element>): Outline => {
     const color = Css.get(elm, 'outline-color');
-    const width = Css.get(elm, 'outline-width');
     const style = Css.get(elm, 'outline-style');
+    const width = style === 'none' ? '0px' : Css.get(elm, 'outline-width');
     return {
       color,
       width,


### PR DESCRIPTION
Chrome 147 changed the computed outline-width value from '0px' to a non-zero value when outline-style is 'none'. Normalize outline-width to '0px' when outline-style is 'none' in the test helper.

1. Resolves #190
2. No breaking changes.
3. This is a test fix — no changes to editor behavior.
4. This modifies an existing test to handle a Chrome behavior change.