### PR TITLE
test: fix EditorContentTest expectation for attribute value escaping

### DIFF
--- a/modules/hugerte/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/hugerte/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -292,10 +292,9 @@ describe('browser.hugerte.core.content.EditorContentTest', () => {
         });
 
         it('TINY-10088: Preserve attributes with self closed HTML tag', () => {
-          const content = '<div data-some-attribute="title=<br/>">abc</div>';
           const editor = hook.editor();
-          editor.setContent(content);
-          TinyAssertions.assertContent(editor, content, { format: 'raw' });
+          editor.setContent('<div data-some-attribute="title=<br/>">abc</div>');
+          TinyAssertions.assertContent(editor, '<div data-some-attribute="title=&lt;br/&gt;">abc</div>', { format: 'raw' });
         });
 
         const initialContent = '<p>initial</p>';


### PR DESCRIPTION
The TINY-10088 test expected unescaped angle brackets in attribute values, but the serializer correctly encodes them as HTML entities. Update the assertion to match the correct behavior.

Closes #193

1. This pull request resolves #193.
2. This pull request does not contain breaking changes. Editor behavior remains unchanged.
3. This is a test fix - the test expectation was obsolete.
4. This pull request updates an existing test to match the current behavior.